### PR TITLE
link to more appropriate parts of the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@ permalink: /
       </div>
       {% endfor %}
       <div class="action-btns text-center">
-        <a href="https://envoyproxy.github.io/envoy/index.html" class="btn btn-primary">Get Started</a>
-        <a href="download" class="btn btn-secondary">Download</a>
+        <a href="https://www.envoyproxy.io/docs/envoy/latest/install/getting_started" class="btn btn-primary">Get Started</a>
+        <a href="https://www.envoyproxy.io/docs/envoy/latest/install/building" class="btn btn-secondary">Download</a>
       </div>
     </div>
 


### PR DESCRIPTION
Change Get Started button to point to the updated Getting Started.
Change the Download button to point to the Building/Install docs.

Signed-off-by: Richard Li <richard@datawire.io>