### PR TITLE
Fix broken getting started link

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ permalink: /
       </div>
       {% endfor %}
       <div class="action-btns text-center">
-        <a href="https://www.envoyproxy.io/docs/envoy/latest/install/getting_started" class="btn btn-primary">Get Started</a>
+        <a href="https://www.envoyproxy.io/docs/envoy/latest/start/start" class="btn btn-primary">Get Started</a>
         <a href="https://www.envoyproxy.io/docs/envoy/latest/install/building" class="btn btn-secondary">Download</a>
       </div>
     </div>


### PR DESCRIPTION
Currently `https://www.envoyproxy.io/docs/envoy/latest/install/getting_started` is returning a 404.

Signed-off-by: Anubhav Mishra <anubhavmishra@me.com>