### PR TITLE
fix broken links to front-envoy and service-envoy configs

### DIFF
--- a/docs/envoy/latest/start/sandboxes/front_proxy.html
+++ b/docs/envoy/latest/start/sandboxes/front_proxy.html
@@ -198,9 +198,9 @@ called <code class="docutils literal"><span class="pre">envoymesh</span></code>.
 the edge of the <code class="docutils literal"><span class="pre">envoymesh</span></code> network. Port <code class="docutils literal"><span class="pre">80</span></code> is mapped to  port <code class="docutils literal"><span class="pre">8000</span></code> by docker compose
 (see <a class="reference external" href="https://github.com/envoyproxy/envoy/blob/master//examples/front-proxy/docker-compose.yml">/examples/front-proxy/docker-compose.yml</a>). Moreover, notice
 that all  traffic routed by the front envoy to the service containers is actually routed to the
-service envoys (routes setup in <a class="reference external" href="https://github.com/envoyproxy/envoy/blob/master//examples/front-proxy/front-envoy.json">/examples/front-proxy/front-envoy.json</a>). In turn the service
+service envoys (routes setup in <a class="reference external" href="https://github.com/envoyproxy/envoy/blob/master//examples/front-proxy/front-envoy.yaml">/examples/front-proxy/front-envoy.json</a>). In turn the service
 envoys route the  request to the flask app via the loopback address (routes setup in
-<a class="reference external" href="https://github.com/envoyproxy/envoy/blob/master//examples/front-proxy/service-envoy.json">/examples/front-proxy/service-envoy.json</a>). This setup
+<a class="reference external" href="https://github.com/envoyproxy/envoy/blob/master//examples/front-proxy/service-envoy.yaml">/examples/front-proxy/service-envoy.json</a>). This setup
 illustrates the advantage of running service envoys  collocated with your services: all requests are
 handled by the service envoy, and efficiently routed to your services.</p>
 <div class="section" id="running-the-sandbox">


### PR DESCRIPTION
point to v2 configs for front-envoy and service-envoy sandbox examples