### PR TITLE
Add a link to v1.6.0 docs in the docs page

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -4,4 +4,5 @@ title: Documentation
 ---
 
 * [Latest](https://www.envoyproxy.io/docs/envoy/latest/)
+* [1.6](https://www.envoyproxy.io/docs/envoy/v1.6.0/)
 * [1.5](https://www.envoyproxy.io/docs/envoy/v1.5.0/)


### PR DESCRIPTION
We already released v1.6.0. Probably, follow up PR of https://github.com/envoyproxy/envoyproxy.github.io/pull/29.

@richarddli ?

Signed-off-by: Taiki Ono <taiki-ono@cookpad.com>