### PR TITLE
Fix Getting Started typo, is -> it

### DIFF
--- a/docs/envoy/latest/_sources/start/start.rst.txt
+++ b/docs/envoy/latest/_sources/start/start.rst.txt
@@ -116,7 +116,7 @@ And now you can execute it with::
 
   $ docker run -d --name envoy -p 9901:9901 -p 10000:10000 envoy:v1
 
-And finally test is using::
+And finally test it using::
 
   $ curl -v localhost:10000
 

--- a/docs/envoy/latest/start/start.html
+++ b/docs/envoy/latest/start/start.html
@@ -279,7 +279,7 @@ COPY envoy.yaml /etc/envoy/envoy.yaml
 <div class="highlight-default"><div class="highlight"><pre><span></span>$ docker run -d --name envoy -p 9901:9901 -p 10000:10000 envoy:v1
 </pre></div>
 </div>
-<p>And finally test is using:</p>
+<p>And finally test it using:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span>$ curl -v localhost:10000
 </pre></div>
 </div>

--- a/docs/envoy/v1.6.0/_sources/start/start.rst.txt
+++ b/docs/envoy/v1.6.0/_sources/start/start.rst.txt
@@ -124,7 +124,7 @@ And now you can execute it with::
 
   $ docker run -d --name envoy -p 9901:9901 -p 10000:10000 envoy:v1
 
-And finally test is using::
+And finally test it using::
 
   $ curl -v localhost:10000
 

--- a/docs/envoy/v1.6.0/start/start.html
+++ b/docs/envoy/v1.6.0/start/start.html
@@ -285,7 +285,7 @@ CMD /usr/local/bin/envoy -c /etc/envoy.yaml
 <div class="highlight-default"><div class="highlight"><pre><span></span>$ docker run -d --name envoy -p 9901:9901 -p 10000:10000 envoy:v1
 </pre></div>
 </div>
-<p>And finally test is using:</p>
+<p>And finally test it using:</p>
 <div class="highlight-default"><div class="highlight"><pre><span></span>$ curl -v localhost:10000
 </pre></div>
 </div>


### PR DESCRIPTION
Fixing small typo in Getting Started documentation, seen here https://www.envoyproxy.io/docs/envoy/latest/start/start#using-the-envoy-docker-image