### PR TITLE
Change design of Envoy version button

### DIFF
--- a/_sass/home.scss
+++ b/_sass/home.scss
@@ -17,17 +17,17 @@
 }
 
 .envoy-version-number {
-  height: 72px;
-  width: 72px;
+  padding: 0 2.5rem;
   display: inline-block;
   line-height: 68px;
   text-align: center;
-  color: $color-white;
-  border: 2px solid #fff;
-  border-radius: 30px;
+  min-width: 72px;
+  border-radius: .5rem;
+  background-color: $color-white;
+  color: $color-purple;
   font-size: 36px;
   font-weight: 300;
-  margin: 75px 0 15px;
+  margin: 5rem 0 3rem 0;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -6,9 +6,9 @@ permalink: /
 
 <div id="home">
 
-  <section id="hero" class="home-section bg-purple">
+  <section id="hero" class="home-section bg-purple text-center">
 
-    <div class="container text-center">
+    <div class="container">
       {% for hero in site.data.home.hero %}
       <div class="hero-information">
         <h1><img src="{{ hero.image }}" alt="Envoy"></h1>
@@ -23,13 +23,13 @@ permalink: /
       </div>
     </div>
 
-    <div class="text-center">
-      <div class="envoy-version-number">
-        {{ site.latest }}
-      </div>
-      <div>
-        <strong class="font-big font-bold text-white">Envoy {{ site.latest }} is now available</strong>
-      </div>
+    <div>
+      <span class="envoy-version-number" href="">
+        Envoy <strong>{{ site.latest }}</strong> is now available
+      </span>
+
+      <br />
+
       <a class="font-big font-light text-white" href="https://www.envoyproxy.io/docs/envoy/v{{ site.latest }}/intro/version_history">Read the changelog</a>
     </div>
 


### PR DESCRIPTION
Previous:

<img width="1023" alt="screen shot 2018-10-10 at 10 54 11 am" src="https://user-images.githubusercontent.com/1523104/46755821-e384ae80-cc7a-11e8-8e73-dc665d895fad.png">

Proposed:

<img width="1009" alt="screen shot 2018-10-10 at 10 54 03 am" src="https://user-images.githubusercontent.com/1523104/46755828-e8e1f900-cc7a-11e8-8400-6e5448b527b6.png">
