### PR TITLE
Update README to mention how to run Envoy Proxy website using Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ bundle exec jekyll serve --livereload
 
 4. Preview the site in your web browser at http://localhost:4000.
 
+### Running the site locally using Docker
+
+To run the website locally using Docker, run the command:
+
+```shell
+docker run -it -v $(pwd):/srv/jekyll -p 4000:4000 jekyll/jekyll jekyll serve --watch --incremental
+```
+
+Alternatively, use Docker Compose with:
+
+```shell
+docker-compose up
+```
+
+Preview the site in your web browser at http://localhost:4000.
+
 ### Deploying to Github Pages
 
 To deploy your changes all you have to do is push to `master` and Github pages will automatically run `jekyll build` and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+jekyll:
+    image: jekyll/jekyll
+    command: jekyll serve --watch --incremental
+    ports:
+        - 4000:4000
+    volumes:
+        - .:/srv/jekyll


### PR DESCRIPTION
Installing Ruby on OSX wasn't a happy experience so I went with a Docker Container. Providing the command for the next time :)