### PR TITLE
Embed Katacoda interactive scenarios under /try

### DIFF
--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -10,5 +10,8 @@
 - text: Learn
   url: /learn
 
+- text: Try
+  url: /try
+
 - text: Community
   url: /community

--- a/_layouts/try.html
+++ b/_layouts/try.html
@@ -1,0 +1,22 @@
+---
+layout: default
+---
+<div id="default-page">
+  <div class="katacoda-container">
+    <div class="row">
+      <div class="col-sm-12 content-area">
+        <header class="learn-header">
+          <h1 class="heading-big text-purple text-uppercase" itemprop="name headline">{{ page.title | escape }}</h1>
+
+          {% if page.description %}
+          <h3 class="learn-description">{{ page.description }}</h3>
+          {% endif %}
+        </header>
+
+        <div class="page-content">
+          {{ content }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -31,3 +31,8 @@ body {
 .container {
   max-width: 990px;
 }
+
+.katacoda-container {
+  margin: 0 50px;
+  padding: 0;
+}

--- a/try/api-based-dynamic-routing-configuration.md
+++ b/try/api-based-dynamic-routing-configuration.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/api-based-dynamic-routing-configuration"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/blue-green-deployments.md
+++ b/try/blue-green-deployments.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/blue-green-deployments"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/detecting-service-health-with-healthchecks.md
+++ b/try/detecting-service-health-with-healthchecks.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/detecting-service-health-with-healthchecks"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/file-based-dynamic-routing-configuration.md
+++ b/try/file-based-dynamic-routing-configuration.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/file-based-dynamic-routing-configuration"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/getting-started.md
+++ b/try/getting-started.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/getting-started"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/implementing-metrics-tracing.md
+++ b/try/implementing-metrics-tracing.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/implementing-metrics-tracing"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/index.md
+++ b/try/index.md
@@ -1,0 +1,18 @@
+---
+layout: try
+title: Try Envoy
+description: >
+  Try Envoy Proxy  using real environments right in your browser with a series of interactive labs. The interactive labs help you get started and learn how to run Envoy in production.
+---
+
+<div id="katacoda-dashboard"
+        data-katacoda-id="envoyproxy/homepage/dashboard"
+        data-katacoda-startscenariobuttontext="Start Scenario"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:800px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/migrating-from-haproxy-to-envoy.md
+++ b/try/migrating-from-haproxy-to-envoy.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/migrating-from-haproxy-to-envoy"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/migrating-from-nginx-to-envoy.md
+++ b/try/migrating-from-nginx-to-envoy.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/migrating-from-nginx-to-envoy"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>

--- a/try/securing-traffic-with-https.md
+++ b/try/securing-traffic-with-https.md
@@ -1,0 +1,16 @@
+---
+layout: try
+---
+
+<div id="katacoda-scenario"
+        data-katacoda-id="envoyproxy/securing-traffic-with-https"
+        data-katacoda-ctatext="Continue Learning"
+        data-katacoda-ctaurl="https://www.envoyproxy.io/try"
+        data-katacoda-color="#b12d77"
+        data-katacoda-secondary="#1f0d42"
+        data-katacoda-background="#fff"
+        data-katacoda-hideprogress="true"
+        data-katacoda-font="Open Sans"
+        data-katacoda-fontheader="Open Sans" style="height:650px;">
+      </div>
+<script src="https://katacoda.com/embed.js"></script>


### PR DESCRIPTION
Embed the Katacoda interactive scenarios as https://www.envoyproxy.io/try as /learn is the Turbine Labs series. I think /try added a nice addition and capture users interest. 

The index page displays all the content available:

![screenshot 2018-12-06 11 34 57](https://user-images.githubusercontent.com/82614/49582761-f26fa080-f94d-11e8-999c-e9ab4054081a.png)

This takes the user to the page where they can complete the scenario.

![screenshot 2018-12-06 11 16 09](https://user-images.githubusercontent.com/82614/49582765-f69bbe00-f94d-11e8-92c5-e626845af6e0.png)
