### PR TITLE
Fix some typos in docs

### DIFF
--- a/learn/automatic-retries.md
+++ b/learn/automatic-retries.md
@@ -112,7 +112,7 @@ will allow several retries, accounting for the jitter that Envoy adds between
 calls.
 
 On the other hand, if the request makes many parallel requests (“high fan-out”)
-without an aggresive global timeout, adding retries will result in consistently
+without an aggressive global timeout, adding retries will result in consistently
 poor performance. Imagine a service (with no global timeout) that makes 100
 requests with an average of 150ms latency and a 500ms timeout on each upstream
 called. Without retries, the request will be bounded at ~500ms -- either the

--- a/learn/health-check.md
+++ b/learn/health-check.md
@@ -1,6 +1,6 @@
 ---
 layout: learn
-title: Healthly Hosts in Envoy
+title: Healthy Hosts in Envoy
 description: >
   Envoy can be configured with both active and passive health checking in
   order to make the best load balancing decision possible. See how to configure

--- a/learn/routing-basics.md
+++ b/learn/routing-basics.md
@@ -21,7 +21,7 @@ with static files.
 
 A route is a set of rules that match virtual hosts to clusters and allow you to
 create traffic shifting rules. Routes are configured either via static
-definion, or via the route discovery service (RDS).
+definition, or via the route discovery service (RDS).
 
 ### Cluster
 


### PR DESCRIPTION
1. "aggresive" to "aggressive" in line 115.
2. "Healthly" to "Healthy" in line 3.
3. "definion" to "definition" in line 24.