### PR TITLE
Learn Envoy: Fixing an outdated URL

### DIFF
--- a/learn/automatic-retries.md
+++ b/learn/automatic-retries.md
@@ -132,4 +132,4 @@ service. Global circuit breaking helps selectively shed load when this sort of
 failure occurs, preventing it from cascading to multiple services.
 
 For more detail, and advanced configuration information, read about them in the
-[Envoy docs](https://www.envoyproxy.io/docs/envoy/latest/api-v1/route_config/route.html#config-http-conn-man-route-table-route-retry).
+[Envoy docs](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v1/route_config/route.html#config-http-conn-man-route-table-route-retry).


### PR DESCRIPTION
The [old URL](https://www.envoyproxy.io/docs/envoy/latest/api-v1/route_config/route.html#config-http-conn-man-route-table-route-retry) is currently returning a 404 - it looks like the last version of the api docs for which the link is active is v1.8.0 so modifying it to point to that.
