### PR TITLE
Fix table layout by removing blank line [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Item | Path
 :----|:----
 Home page content | [`_data/home.yml`](./_data/home.yml)
 Nav links on the main page | [`_data/nav.yml`](./_data/nav.yml)
-
 Documentation (auto-generated) | [`docs`](./docs)
 
 ### Creating New Pages


### PR DESCRIPTION
The blank line is causing the last line of the table to be rendered
outside of the table, when it should be included as part of it.