### PR TITLE
Add robots.txt file to control documentation indexing

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+---
+---
+User-agent: *
+{% for version in site.versions %}
+Disallow: /docs/envoy/{{ version }}/{% endfor %}


### PR DESCRIPTION
Addresses issue [#8838](https://github.com/envoyproxy/envoy/issues/8838) in the main Envoy repo.

This PR automatically generates a `robots.txt` file that disallows indexing of all documentation versions besides `latest`. This was initially proposed in the [main Envoy repo](https://github.com/envoyproxy/envoy/pull/9766) but it's much easier to automate here in the website repo given that the list of versions is available in `_config.yml`.

You can see the generated file here:

https://deploy-preview-139--beggar-construction-36308.netlify.com/robots.txt