### PR TITLE
Fix "Read the changelog" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ permalink: /
 
       <br />
 
-      <a class="font-big font-light text-white" href="https://www.envoyproxy.io/docs/envoy/v{{ site.latest }}/intro/version_history">Read the changelog</a>
+      <a class="font-big font-light text-white" href="https://www.envoyproxy.io/docs/envoy/v{{ site.latest }}/version_history/current">Read the changelog</a>
     </div>
 
   </section>


### PR DESCRIPTION
The link used to take to the old [intro/version_history](https://www.envoyproxy.io/docs/envoy/v1.15.0/intro/version_history) page, we can just link to the newest one or maybe to the [version history listing](https://www.envoyproxy.io/docs/envoy/v1.15.0/version_history/version_history#version-history) page.