### PR TITLE
Add a banner for EnvoyCon 2020

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,14 +1,20 @@
 <header class="header bg-purple container-fluid">
-    <div class="row">
-      <div class="col-sm-3 logo">
-        {% if page.title != 'Home' %}
-          <a href="/">
-            <img src="/img/envoy-logo.svg" alt="Envoy">
-          </a>
-        {% endif %}
-      </div>
-      <div class="col-sm-6">
-        {% include nav.html %}
-      </div>
+    
+  <div class="row">
+    <div class="col-sm-3 logo">
+      {% if page.title != 'Home' %}
+        <a href="/">
+          <img src="/img/envoy-logo.svg" alt="Envoy">
+        </a>
+      {% endif %}
     </div>
+    <div class="col-sm-6">
+      {% include nav.html %}
+    </div>
+  </div>
+  <div class="announcement-banner">
+    <p class="font-light">
+      Register for <a target="_blank" href="https://events.linuxfoundation.org/envoycon">EnvoyCon 2020 Virtual | October 15, 2020</a>
+    </p>
+  </div>
 </header>


### PR DESCRIPTION
This PR adds a banner for EnvoyCon 2020 registration to the site header. It implements a CSS class introduced in #56, and is essentially a retread of that PR. (Thanks, @dansipple. 👋 )

/cc @celestehorgan @caniszczyk 

## Preview screenshot

![Screen Shot 2020-09-24 at 5 11 41 PM](https://user-images.githubusercontent.com/3210446/94212582-6b284f80-fe89-11ea-8c97-c7025da962a1.png)
