### PR TITLE
Fix runtime feature variable name

### DIFF
--- a/docs/envoy/latest/_sources/version_history/v1.12.7.rst.txt
+++ b/docs/envoy/latest/_sources/version_history/v1.12.7.rst.txt
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,4 +17,4 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.

--- a/docs/envoy/latest/_sources/version_history/v1.13.5.rst.txt
+++ b/docs/envoy/latest/_sources/version_history/v1.13.5.rst.txt
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/latest/_sources/version_history/v1.14.5.rst.txt
+++ b/docs/envoy/latest/_sources/version_history/v1.14.5.rst.txt
@@ -6,7 +6,7 @@ Changes
   This patch changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/latest/_sources/version_history/v1.15.1.rst.txt
+++ b/docs/envoy/latest/_sources/version_history/v1.15.1.rst.txt
@@ -7,7 +7,7 @@ Changes
   headers. This patch changes the default behavior to always logically match on all headers.
   Multiple individual headers will be logically concatenated with ',' similar to what is done with
   inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-  reverted by setting the runtime value "envoy.reloadable_features.header_match_on_all_headers" to
+  reverted by setting the runtime value "envoy.reloadable_features.http_match_on_all_headers" to
   "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
@@ -19,7 +19,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/latest/version_history/v1.12.7.html
+++ b/docs/envoy/latest/version_history/v1.12.7.html
@@ -232,7 +232,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 </ul>
 </div>

--- a/docs/envoy/latest/version_history/v1.13.5.html
+++ b/docs/envoy/latest/version_history/v1.13.5.html
@@ -232,7 +232,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/latest/version_history/v1.14.5.html
+++ b/docs/envoy/latest/version_history/v1.14.5.html
@@ -232,7 +232,7 @@
 This patch changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/latest/version_history/v1.15.1.html
+++ b/docs/envoy/latest/version_history/v1.15.1.html
@@ -232,7 +232,7 @@
 headers. This patch changes the default behavior to always logically match on all headers.
 Multiple individual headers will be logically concatenated with ‘,’ similar to what is done with
 inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-reverted by setting the runtime value “envoy.reloadable_features.header_match_on_all_headers” to
+reverted by setting the runtime value “envoy.reloadable_features.http_match_on_all_headers” to
 “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
@@ -245,7 +245,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.12.7/_sources/intro/version_history.rst.txt
+++ b/docs/envoy/v1.12.7/_sources/intro/version_history.rst.txt
@@ -9,7 +9,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -20,7 +20,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 
 1.12.6 (July 7, 2020)
 =====================

--- a/docs/envoy/v1.12.7/intro/version_history.html
+++ b/docs/envoy/v1.12.7/intro/version_history.html
@@ -212,7 +212,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -224,7 +224,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 </ul>
 <div class="section" id="july-7-2020">

--- a/docs/envoy/v1.13.5/_sources/intro/version_history.rst.txt
+++ b/docs/envoy/v1.13.5/_sources/intro/version_history.rst.txt
@@ -9,7 +9,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -20,7 +20,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.13.5/intro/version_history.html
+++ b/docs/envoy/v1.13.5/intro/version_history.html
@@ -213,7 +213,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -225,7 +225,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.13.6/_sources/intro/version_history.rst.txt
+++ b/docs/envoy/v1.13.6/_sources/intro/version_history.rst.txt
@@ -15,7 +15,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -26,7 +26,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.13.6/intro/version_history.html
+++ b/docs/envoy/v1.13.6/intro/version_history.html
@@ -226,7 +226,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -238,7 +238,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.14.5/_sources/intro/version_history.rst.txt
+++ b/docs/envoy/v1.14.5/_sources/intro/version_history.rst.txt
@@ -9,7 +9,7 @@ Changes
   This patch changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -20,7 +20,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.14.5/intro/version_history.html
+++ b/docs/envoy/v1.14.5/intro/version_history.html
@@ -219,7 +219,7 @@
 This patch changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -231,7 +231,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.15.2/_sources/version_history/v1.15.1.rst.txt
+++ b/docs/envoy/v1.15.2/_sources/version_history/v1.15.1.rst.txt
@@ -7,7 +7,7 @@ Changes
   headers. This patch changes the default behavior to always logically match on all headers.
   Multiple individual headers will be logically concatenated with ',' similar to what is done with
   inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-  reverted by setting the runtime value `envoy.reloadable_features.header_match_on_all_headers` to
+  reverted by setting the runtime value `envoy.reloadable_features.http_match_on_all_headers` to
   "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
@@ -19,7 +19,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value `envoy.reloadable_features.header_match_on_all_headers` to false.
+  the runtime value `envoy.reloadable_features.http_match_on_all_headers` to false.
 * http: the setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.15.2/version_history/v1.15.1.html
+++ b/docs/envoy/v1.15.2/version_history/v1.15.1.html
@@ -214,7 +214,7 @@
 headers. This patch changes the default behavior to always logically match on all headers.
 Multiple individual headers will be logically concatenated with ‘,’ similar to what is done with
 inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-reverted by setting the runtime value <cite>envoy.reloadable_features.header_match_on_all_headers</cite> to
+reverted by setting the runtime value <cite>envoy.reloadable_features.http_match_on_all_headers</cite> to
 “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
@@ -227,7 +227,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value <cite>envoy.reloadable_features.header_match_on_all_headers</cite> to false.</p>
+the runtime value <cite>envoy.reloadable_features.http_match_on_all_headers</cite> to false.</p>
 </li>
 <li><p>http: the setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.16.0/_sources/version_history/v1.12.7.rst.txt
+++ b/docs/envoy/v1.16.0/_sources/version_history/v1.12.7.rst.txt
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,4 +17,4 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.

--- a/docs/envoy/v1.16.0/_sources/version_history/v1.13.5.rst.txt
+++ b/docs/envoy/v1.16.0/_sources/version_history/v1.13.5.rst.txt
@@ -6,7 +6,7 @@ Changes
   changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.16.0/_sources/version_history/v1.14.5.rst.txt
+++ b/docs/envoy/v1.16.0/_sources/version_history/v1.14.5.rst.txt
@@ -6,7 +6,7 @@ Changes
   This patch changes the default behavior to always logically match on all headers. Multiple individual
   headers will be logically concatenated with ',' similar to what is done with inline headers. This
   makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to "false".
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
   consider all duplicate headers by default as a comma concatenated list:
@@ -17,7 +17,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.16.0/_sources/version_history/v1.15.1.rst.txt
+++ b/docs/envoy/v1.16.0/_sources/version_history/v1.15.1.rst.txt
@@ -7,7 +7,7 @@ Changes
   headers. This patch changes the default behavior to always logically match on all headers.
   Multiple individual headers will be logically concatenated with ',' similar to what is done with
   inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-  reverted by setting the runtime value "envoy.reloadable_features.header_match_on_all_headers" to
+  reverted by setting the runtime value "envoy.reloadable_features.http_match_on_all_headers" to
   "false".
 
   Targeted fixes have been additionally performed on the following extensions which make them
@@ -19,7 +19,7 @@ Changes
     4. The Lua filter.
 
   Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-  the runtime value "envoy.reloadable_features.header_match_on_all_headers" to false.
+  the runtime value "envoy.reloadable_features.http_match_on_all_headers" to false.
 * http: The setCopy() header map API previously only set the first header in the case of duplicate
   non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found
   headers with a single value. This may have had security implications in the extauth filter which

--- a/docs/envoy/v1.16.0/version_history/v1.12.7.html
+++ b/docs/envoy/v1.16.0/version_history/v1.12.7.html
@@ -232,7 +232,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 </ul>
 </div>

--- a/docs/envoy/v1.16.0/version_history/v1.13.5.html
+++ b/docs/envoy/v1.16.0/version_history/v1.13.5.html
@@ -232,7 +232,7 @@
 changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.16.0/version_history/v1.14.5.html
+++ b/docs/envoy/v1.16.0/version_history/v1.14.5.html
@@ -232,7 +232,7 @@
 This patch changes the default behavior to always logically match on all headers. Multiple individual
 headers will be logically concatenated with ‘,’ similar to what is done with inline headers. This
 makes the behavior effectively consistent. This behavior can be temporary reverted by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to “false”.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
 <blockquote>
@@ -244,7 +244,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: fixed CVE-2020-25017. The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found

--- a/docs/envoy/v1.16.0/version_history/v1.15.1.html
+++ b/docs/envoy/v1.16.0/version_history/v1.15.1.html
@@ -232,7 +232,7 @@
 headers. This patch changes the default behavior to always logically match on all headers.
 Multiple individual headers will be logically concatenated with ‘,’ similar to what is done with
 inline headers. This makes the behavior effectively consistent. This behavior can be temporary
-reverted by setting the runtime value “envoy.reloadable_features.header_match_on_all_headers” to
+reverted by setting the runtime value “envoy.reloadable_features.http_match_on_all_headers” to
 “false”.</p>
 <p>Targeted fixes have been additionally performed on the following extensions which make them
 consider all duplicate headers by default as a comma concatenated list:</p>
@@ -245,7 +245,7 @@ consider all duplicate headers by default as a comma concatenated list:</p>
 </ol>
 </div></blockquote>
 <p>Like primary header matching used in routing, RBAC, etc. this behavior can be disabled by setting
-the runtime value “envoy.reloadable_features.header_match_on_all_headers” to false.</p>
+the runtime value “envoy.reloadable_features.http_match_on_all_headers” to false.</p>
 </li>
 <li><p>http: The setCopy() header map API previously only set the first header in the case of duplicate
 non-inline headers. setCopy() now behaves similarly to the other set*() APIs and replaces all found


### PR DESCRIPTION
- change the runtime feature var name from
`envoy.reloadable_features.header_match_on_all_headers` to
`envoy.reloadable_features.http_match_on_all_headers` as this is
actually the variable defined in the code.
See:
https://github.com/envoyproxy/envoy/blob/master/source/common/runtime/runtime_features.cc
as the source of truth.

Signed-off-by: Denis Zaitcev <denis@tetrate.io>