### PR TITLE
Remove EnvoyCon 2020 banner

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,9 +12,4 @@
       {% include nav.html %}
     </div>
   </div>
-  <div class="announcement-banner">
-    <p class="font-light">
-      Register for <a target="_blank" href="https://events.linuxfoundation.org/envoycon">EnvoyCon 2020 Virtual | October 15, 2020</a>
-    </p>
-  </div>
 </header>


### PR DESCRIPTION
## Description

This PR removes the site banner for EnvoyCon 2020, which concluded on October 15.

/ref #170, #56 
/cc @kkenlaw

## Local preview of changes

![Screen Shot 2020-10-26 at 12 31 30 PM](https://user-images.githubusercontent.com/3210446/97219747-a7501800-1787-11eb-8439-8a1f0421558e.png)
