### PR TITLE
connect_timeout is mandatory for envoy to start

### DIFF
--- a/docs/envoy/latest/_downloads/92dcb9714fb6bc288d042029b34c0de4/envoy-demo.yaml
+++ b/docs/envoy/latest/_downloads/92dcb9714fb6bc288d042029b34c0de4/envoy-demo.yaml
@@ -44,6 +44,7 @@ static_resources:
               socket_address:
                 address: www.envoyproxy.io
                 port_value: 443
+    connect_timeout: 5s
     transport_socket:
       name: envoy.transport_sockets.tls
       typed_config:


### PR DESCRIPTION
added that entry, and set it to 5s arbitrarily .