### PR TITLE
adding redirect for Slack invite link.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,9 @@ command = "./build-website.sh"
 
 [context.deploy-preview.environment]
   JEKYLL_ENV = "staging"
+
+# Redirect to Slack invite link.
+[[redirects]]
+from = "/slack"
+to = "https://join.slack.com/t/envoyproxy/shared_invite/zt-jfib52g3-e4Zqbaw2biDWwEsa8EF60Q"
+status = 302


### PR DESCRIPTION
Adding Netlify redirect so that:
 * https://envoyproxy.io/slack --> https://join.slack.com/t/envoyproxy/shared_invite/zt-jfib52g3-e4Zqbaw2biDWwEsa8EF60Q

As per helpdesk request [CNCFSD-1082](https://cncfservicedesk.atlassian.net/browse/CNCFSD-1082)